### PR TITLE
feat: added slight audio filtering using speechmatics volume threshold

### DIFF
--- a/frontend/src/components/Home.tsx
+++ b/frontend/src/components/Home.tsx
@@ -87,6 +87,9 @@ const Home: React.FC = () => {
           language: "en",
           operating_point: "enhanced",
           max_delay: 1.0,
+          audio_filtering_config: {
+            volume_threshold: 1.0,
+          },
           transcript_filtering_config: {
             remove_disfluencies: true,
           },


### PR DESCRIPTION
Audio Filtering pre-processes input audio to remove low-volume background speech which might otherwise be detected and transcribed.

- Added audio filtering for low volume background speech so it remains undetected

How to test:
1. Press Start
2. Try to talk while having a someone with a soft voice talk behind you
3. Ensure the soft voice is not being picked up by the transcript
4. If it is, we can always adjust this threshold to be a higher number